### PR TITLE
Refine methods called for chart creation and adjust JFrame dimensions

### DIFF
--- a/Portfolios.java
+++ b/Portfolios.java
@@ -27,10 +27,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-
-            createGraph();
-
-
+            createGraph(8);
 
 
         }
@@ -44,9 +41,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-
-            createGraph();
-
+            createGraph(5);
 
         }
         return panel;
@@ -155,7 +150,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphLow();
 
 
         }
@@ -171,7 +166,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphLow();
 
 
         }
@@ -197,7 +192,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphLow();
 
 
         }
@@ -213,7 +208,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphLow();
 
         }
 
@@ -238,7 +233,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphLow();
 
         }
         if (option == 1) {
@@ -253,7 +248,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphLow();
 
 
         }
@@ -282,7 +277,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
         if (option == 1) {
@@ -297,7 +292,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
 
@@ -322,7 +317,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
         if (option == 1) {
@@ -337,7 +332,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
 
@@ -362,7 +357,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
 
         }
@@ -378,7 +373,7 @@ public class Portfolios {
             descriptionLabel.setText("<html>" + description + "</html>");
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
 
         }
@@ -404,7 +399,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
         if (option == 1) {
@@ -419,7 +414,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
 
@@ -444,7 +439,7 @@ public class Portfolios {
             descriptionLabel.setFont(new Font("Arial", Font.PLAIN, 14));
             descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
             panel.add(descriptionLabel, BorderLayout.CENTER);
-            createGraph();
+            createGraphMed();
 
         }
         if (option == 1) {

--- a/ProfileUtil.java
+++ b/ProfileUtil.java
@@ -15,6 +15,7 @@ public class ProfileUtil {
         // Risk amount
         if (risk == 1) {
             code.append('1');
+
         } else if (risk == 2) {
             code.append('2');
         } else if (risk == 3) {

--- a/Survey.java
+++ b/Survey.java
@@ -29,20 +29,7 @@ public class Survey extends JFrame implements ActionListener {
 
         // Function to set size of JFrame.
         setTitle("Survey");
-        setSize(new Dimension(500, 400));
-        setLocationRelativeTo(null);
-
-
-
-        // Function to set visibility of JFrame.
-        setVisible(true);
-
-        // Function to set default operation of JFrame.
-        setDefaultCloseOperation(EXIT_ON_CLOSE);
-
-        // Function to set size of JFrame.
-        setTitle("Survey");
-        setSize(new Dimension(400, 400));
+        setSize(new Dimension(600, 400));
         setLocationRelativeTo(null);
 
 


### PR DESCRIPTION
Update the `createGraph` method calls in `Portfolios.java`, passing in integer values or switching to `createGraphLow` and `createGraphMed` methods according to the section needs. Additionally, in `Survey.java`, adjust the JFrame dimensions from 400x400 or 500x400 to a uniform 600x400 for consistency. These changes aim to improve the usability of the portfolio charts and enhance the overall user interface.